### PR TITLE
[InReview] スタート押下時にエラーとなる不具合修正

### DIFF
--- a/app/src/main/java/jp/co/mihajipo/utility/LocationUtility.kt
+++ b/app/src/main/java/jp/co/mihajipo/utility/LocationUtility.kt
@@ -39,7 +39,6 @@ class LocationUtility private constructor(private val context: Context) {
     interface OnProcessCallbackListener {
         fun onSuccessLocation(latitude: Double, longitude: Double)
         fun onFailedLocation()
-        fun onUnauthorized()
     }
 
     /**
@@ -89,10 +88,6 @@ class LocationUtility private constructor(private val context: Context) {
             override fun onFailedLocation() {
                 TODO("Not yet implemented")
             }
-
-            override fun onUnauthorized() {
-                view.showLocationPermissionDialog()
-            }
         }
         startLocationService()
     }
@@ -137,7 +132,6 @@ class LocationUtility private constructor(private val context: Context) {
                 Manifest.permission.ACCESS_COARSE_LOCATION
             ) !== PackageManager.PERMISSION_GRANTED
         ) {
-            onProcessCallbackListener?.onUnauthorized()
             return
         }
         val lastKnownLocation = locationManager?.getLastKnownLocation(provider)

--- a/app/src/main/java/jp/co/mihajipo/view/BaseActivity.kt
+++ b/app/src/main/java/jp/co/mihajipo/view/BaseActivity.kt
@@ -13,6 +13,7 @@ abstract class BaseActivity : AppCompatActivity() {
         initBinding()
         initPresenter()
         initObserver()
+        showLocationPermissionDialog()
     }
 
     /**
@@ -29,4 +30,9 @@ abstract class BaseActivity : AppCompatActivity() {
      * observerを初期化するIF
      */
     abstract fun initObserver()
+
+    /**
+     * showLocationPermissionDialogを初期化するIF
+     */
+    abstract fun showLocationPermissionDialog()
 }

--- a/app/src/main/java/jp/co/mihajipo/view/MihajipoActivity.kt
+++ b/app/src/main/java/jp/co/mihajipo/view/MihajipoActivity.kt
@@ -1,6 +1,7 @@
 package jp.co.mihajipo.view
 
 import android.Manifest
+import android.app.AlertDialog
 import android.content.Context
 import android.content.pm.PackageManager
 import android.hardware.SensorManager
@@ -67,7 +68,6 @@ class MihajipoActivity : BaseActivity(), MIhajipoContract.View {
     }
 
     override fun showLocationPermissionDialog() {
-        presenter?.stop()
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(
                 this,
@@ -75,9 +75,24 @@ class MihajipoActivity : BaseActivity(), MIhajipoContract.View {
                 100
             )
         }
-        /*
-         TODO 2回「許可しない」を選択した場合、以降のダイアログは表示されない
-         設定を開くか、設定最速するダイアログ表示を追加したい
-        */
+    }
+
+    override fun onRequestPermissionsResult(
+            requestCode: Int,
+            permissions: Array<out String>,
+            grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        // パーミッションを持っていない場合(許可が選択されなかった場合)
+        if (grantResults.all { it != PackageManager.PERMISSION_GRANTED }) {
+            AlertDialog.Builder(this)
+                .setTitle("位置情報の許可がありません")
+                .setMessage("アプリケーションの設定から位置情報を許可してください")
+                .setPositiveButton("OK") { dialog, which ->
+                    // アプリケーションを終了
+                    finish()
+                }
+                .show()
+        }
     }
 }


### PR DESCRIPTION
【開発チケット】
https://report.r-jc.jp/issues/26246

【原因】
位置情報の取得許可が必要であり、許可を承諾するダイアログを表示するメソッドの処理で処理が無限ループになっていることが原因

【修正概要】
①位置情報許可のポップアップを表示するタイミング変更
　スタートボタン押下時⇒アプリケーション表示時
➁許可しないを選択した場合にアプリケーションの設定から位置情報の許可をすることを催促するメッセージ表示追加